### PR TITLE
get stairs after mods loaded

### DIFF
--- a/features/library.lua
+++ b/features/library.lua
@@ -3,7 +3,7 @@ local cids = {
   bookshelf = core.get_content_id("default:bookshelf"),
   torch = core.get_content_id("default:torch"),
   wood = core.get_content_id("default:wood"),
-  stair = core.get_content_id("stairs:stair_outer_wood"),
+  stair = nil, -- get stair node after mods loaded below
   lamp = core.get_content_id("default:mese_post_light"),
 }
 
@@ -13,6 +13,7 @@ local preserve = {
   [core.get_content_id("default:lava_source")] = true,
 }
 core.register_on_mods_loaded(function()
+  cids.stair = core.get_content_id("stairs:stair_outer_wood")
   for node,def in pairs(core.registered_nodes) do
     if node:find("^stairs:stair_") then
       preserve[core.get_content_id(node)] = true

--- a/features/storeroom.lua
+++ b/features/storeroom.lua
@@ -5,9 +5,13 @@ local cids = {
   log = core.get_content_id("default:tree"),
   straw = core.get_content_id("farming:straw"),
   wood = core.get_content_id("default:wood"),
-  slab = core.get_content_id("stairs:slab_wood"),
+  slab = nil, -- get slab below after mods loaded
   bottle = core.get_content_id("vessels:glass_bottle"),
 }
+
+core.register_on_mods_loaded(function()
+  cids.slab = core.get_content_id("stairs:slab_wood")
+end)
 
 local vs = vector.subtract
 


### PR DESCRIPTION
Get the content id's for stair and slab after all mods are loaded, fixes bug when using 3rd party stairs mods.